### PR TITLE
Fix checking validity of sRGB vals near 0 or 255

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,12 +8,15 @@
 	<script type="text/javascript" src="color.js"></script>
 	<script type="text/javascript">
 		<!--
-		function colorname(triple) {
+		function srgb_coords(triple) {
 			var ans = [0, 0, 0];
 			for (var i in ans) {
 				ans[i] = Math.round(triple[i] * 255);
 			}
-			return Color.cssrgb(ans);
+			return ans;
+		}
+		function colorname(triple) {
+			return Color.cssrgb(srgb_coords(triple));
 		}
 		function color_charted(triple) {
 			for (var i in triple) {
@@ -22,8 +25,9 @@
 			return true;
 		}
 		function color_valid(triple) {
-			for (var i in triple) {
-				if (triple[i] < 0 || triple[i] > 1) { return false; }
+			var srgb = srgb_coords(triple);
+			for (var i in srgb) {
+				if (srgb[i] < 0 || srgb[i] > 255) { return false; }
 			}
 			return true;
 		}


### PR DESCRIPTION
Previously if the value of an sRGB coordinate on the 0 <= coord <= 1 scale was less than but close to 0, or greater than but close to 1, it might end up rounding to a valid sRGB triple on the 0–255 scale but the `color_valid` did not know this. This means a very few colours (e.g. 7.5Y 5.00/8.0, 10.0P 1.00/8.0) which could have been shown even with ‘Plot out-of-range colors’ unchecked were hidden from view.

This fixes the problem by making `color_valid` convert and round the colour coordinates to the 0–255 scale used for display before checking to see if they’re in range.
